### PR TITLE
Updating README/setup.py for new location.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 
 This library provides an `httplib2`_ transport for `google-auth`_.
 
-.. note:: ``httplib`` has lots of problems such as lack of threadsafety and
+.. note:: ``httplib`` has lots of problems such as lack of threadsafety
     and insecure usage of TLS. Using it is highly discouraged. This
     library is intended to help existing users of ``oauth2client`` migrate to
     ``google-auth``.
@@ -14,7 +14,7 @@ This library provides an `httplib2`_ transport for `google-auth`_.
    :target: https://pypi.python.org/pypi/google-auth-httplib2
 
 .. _httplib2: https://github.com/httplib2/httplib2
-.. _google-auth: https://github.com/GoogleCloudPlatform/google-auth
+.. _google-auth: https://github.com/GoogleCloudPlatform/google-auth-library-python/
 
 Installing
 ----------

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ from setuptools import setup
 
 
 DEPENDENCIES = (
-    'google-auth'
+    'google-auth',
+    'httplib2 >= 0.9.1',
 )
 
 
@@ -31,9 +32,9 @@ setup(
     version='0.0.2',
     author='Google Cloud Platform',
     author_email='jonwayne+google-auth@google.com',
-    description='Google Authentication Library',
+    description='Google Authentication Library: httplib2 transport',
     long_description=long_description,
-    url='https://github.com/GoogleCloudPlatform/google-auth-library-python',
+    url='https://github.com/GoogleCloudPlatform/google-auth-library-python-httplib2',
     py_modules=['google_auth_httplib2'],
     install_requires=DEPENDENCIES,
     license='Apache 2.0',


### PR DESCRIPTION
- Based on https://github.com/GoogleCloudPlatform/google-auth-library-python/issues/167
- Fixed "and and" typo
- Fixed URL for project
- Updated the package description to explain it was for `httplib2` transport
- Added `httplib2` as a dependency