### PR TITLE
Bug: Catch any underlying exceptions from http.HTTPException

### DIFF
--- a/google_auth_httplib2.py
+++ b/google_auth_httplib2.py
@@ -22,6 +22,11 @@ from google.auth import exceptions
 from google.auth import transport
 import httplib2
 
+# httplib became http.client in 3.x
+try:
+    from http.client import HTTPException
+except ImportError:
+    from httplib import HTTPException
 
 _LOGGER = logging.getLogger(__name__)
 # Properties present in file-like streams / buffers.
@@ -115,7 +120,9 @@ class Request(transport.Request):
             response, data = self.http.request(
                 url, method=method, body=body, headers=headers, **kwargs)
             return _Response(response, data)
-        except httplib2.HttpLib2Error as exc:
+        # TODO: httplib2 should catch the lower http error, this is a bug and
+        # needs to be fixed there.  Catch the error for the meanwhile.
+        except (httplib2.HttpLib2Error, HTTPException) as exc:
             raise exceptions.TransportError(exc)
 
 

--- a/google_auth_httplib2.py
+++ b/google_auth_httplib2.py
@@ -21,7 +21,7 @@ import logging
 from google.auth import exceptions
 from google.auth import transport
 import httplib2
-from six.moves import http_client  # httplib became http.client in 3.
+from six.moves import http_client
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/google_auth_httplib2.py
+++ b/google_auth_httplib2.py
@@ -21,12 +21,8 @@ import logging
 from google.auth import exceptions
 from google.auth import transport
 import httplib2
+from six.moves import http_client  # httplib became http.client in 3.
 
-# httplib became http.client in 3.x
-try:
-    from http.client import HTTPException
-except ImportError:
-    from httplib import HTTPException
 
 _LOGGER = logging.getLogger(__name__)
 # Properties present in file-like streams / buffers.
@@ -120,9 +116,9 @@ class Request(transport.Request):
             response, data = self.http.request(
                 url, method=method, body=body, headers=headers, **kwargs)
             return _Response(response, data)
-        # TODO: httplib2 should catch the lower http error, this is a bug and
+        # httplib2 should catch the lower http error, this is a bug and
         # needs to be fixed there.  Catch the error for the meanwhile.
-        except (httplib2.HttpLib2Error, HTTPException) as exc:
+        except (httplib2.HttpLib2Error, http_client.HTTPException) as exc:
             raise exceptions.TransportError(exc)
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ from setuptools import setup
 DEPENDENCIES = (
     'google-auth',
     'httplib2 >= 0.9.1',
+    'six'
 )
 
 


### PR DESCRIPTION
Resolves https://github.com/GoogleCloudPlatform/google-auth-library-python-httplib2/issues/6

