### PR TITLE
feat: expose a few httplib2 properties and a method

### DIFF
--- a/google_auth_httplib2.py
+++ b/google_auth_httplib2.py
@@ -229,7 +229,7 @@ class AuthorizedHttp(object):
 
     def add_certificate(self, key, cert, domain, password=None):
         """Proxy to httplib2.Http.add_certificate."""
-        self.http.add_certificate(key, cert, domain, password)
+        self.http.add_certificate(key, cert, domain, password=password)
 
     @property
     def connections(self):
@@ -246,7 +246,7 @@ class AuthorizedHttp(object):
         """Proxy to httplib2.Http.follow_redirects."""
         return self.http.follow_redirects
 
-    @connections.setter
+    @follow_redirects.setter
     def follow_redirects(self, value):
         """Proxy to httplib2.Http.follow_redirects."""
         self.http.follow_redirects = value
@@ -256,7 +256,7 @@ class AuthorizedHttp(object):
         """Proxy to httplib2.Http.timeout."""
         return self.http.timeout
 
-    @connections.setter
+    @timeout.setter
     def timeout(self, value):
         """Proxy to httplib2.Http.timeout."""
         self.http.timeout = value

--- a/google_auth_httplib2.py
+++ b/google_auth_httplib2.py
@@ -227,6 +227,10 @@ class AuthorizedHttp(object):
 
         return response, content
 
+    def add_certificate(self, key, cert, domain, password=None):
+        """Proxy to httplib2.Http.add_certificate."""
+        self.http.add_certificate(key, cert, domain, password)
+
     @property
     def connections(self):
         """Proxy to httplib2.Http.connections."""
@@ -236,3 +240,23 @@ class AuthorizedHttp(object):
     def connections(self, value):
         """Proxy to httplib2.Http.connections."""
         self.http.connections = value
+
+    @property
+    def follow_redirects(self):
+        """Proxy to httplib2.Http.follow_redirects."""
+        return self.http.follow_redirects
+
+    @connections.setter
+    def follow_redirects(self, value):
+        """Proxy to httplib2.Http.follow_redirects."""
+        self.http.follow_redirects = value
+
+    @property
+    def timeout(self):
+        """Proxy to httplib2.Http.timeout."""
+        return self.http.timeout
+
+    @connections.setter
+    def timeout(self, value):
+        """Proxy to httplib2.Http.timeout."""
+        self.http.timeout = value

--- a/pylint.config.py
+++ b/pylint.config.py
@@ -25,6 +25,7 @@ library_additions = {
             'protected-access',
             'redefined-variable-type',
             'similarities',
+            'useless-object-inheritance',
             'no-else-return',
         ],
     },

--- a/pylint.config.py
+++ b/pylint.config.py
@@ -27,6 +27,7 @@ library_additions = {
             'similarities',
             'useless-object-inheritance',
             'no-else-return',
+            'wrong-import-order',
         ],
     },
 }

--- a/tests/test_google_auth_httplib2.py
+++ b/tests/test_google_auth_httplib2.py
@@ -26,6 +26,7 @@ class MockHttp(object):
         self.responses = responses
         self.requests = []
         self.headers = headers or {}
+        self.add_certificate = mock.Mock(return_value=None)
 
     def request(self, url, method='GET', body=None, headers=None, **kwargs):
         self.requests.append((method, url, body, headers, kwargs))
@@ -94,6 +95,30 @@ class TestAuthorizedHttp(object):
 
         authed_http.connections = mock.sentinel.connections
         assert authed_http.http.connections == mock.sentinel.connections
+
+    def test_follow_redirects(self):
+        authed_http = google_auth_httplib2.AuthorizedHttp(mock.sentinel.credentials)
+
+        assert authed_http.connections == authed_http.http.connections
+
+        authed_http.follow_redirects = mock.sentinel.follow_redirects
+        assert authed_http.http.follow_redirects == mock.sentinel.follow_redirects
+
+    def test_timeout(self):
+        authed_http = google_auth_httplib2.AuthorizedHttp(mock.sentinel.credentials)
+
+        assert authed_http.timeout == authed_http.http.timeout
+
+        authed_http.timeout = mock.sentinel.timeout
+        assert authed_http.http.timeout == mock.sentinel.timeout
+
+    def test_add_certificate(self):
+        authed_http = google_auth_httplib2.AuthorizedHttp(mock.sentinel.credentials)
+
+        authed_http.add_certificate("key", "cert", "domain", password="password")
+        authed_http.http.add_certificate.assert_called_once_with(
+            "key", "cert", "domain", password="password"
+        )
 
     def test_request_no_refresh(self):
         mock_credentials = mock.Mock(wraps=MockCredentials())

--- a/tests/test_google_auth_httplib2.py
+++ b/tests/test_google_auth_httplib2.py
@@ -97,15 +97,20 @@ class TestAuthorizedHttp(object):
         assert authed_http.http.connections == mock.sentinel.connections
 
     def test_follow_redirects(self):
-        authed_http = google_auth_httplib2.AuthorizedHttp(mock.sentinel.credentials)
+        auth_http = google_auth_httplib2.AuthorizedHttp(
+            mock.sentinel.credentials
+        )
 
-        assert authed_http.follow_redirects == authed_http.http.follow_redirects
+        assert auth_http.follow_redirects == auth_http.http.follow_redirects
 
-        authed_http.follow_redirects = mock.sentinel.follow_redirects
-        assert authed_http.http.follow_redirects == mock.sentinel.follow_redirects
+        mock_follow_redirects = mock.sentinel.follow_redirects
+        auth_http.follow_redirects = mock_follow_redirects
+        assert auth_http.http.follow_redirects == mock_follow_redirects
 
     def test_timeout(self):
-        authed_http = google_auth_httplib2.AuthorizedHttp(mock.sentinel.credentials)
+        authed_http = google_auth_httplib2.AuthorizedHttp(
+            mock.sentinel.credentials
+        )
 
         assert authed_http.timeout == authed_http.http.timeout
 
@@ -118,7 +123,9 @@ class TestAuthorizedHttp(object):
             http=MockHttp(MockResponse())
         )
 
-        authed_http.add_certificate("key", "cert", "domain", password="password")
+        authed_http.add_certificate(
+            "key", "cert", "domain", password="password"
+        )
         authed_http.http.add_certificate.assert_called_once_with(
             "key", "cert", "domain", password="password"
         )

--- a/tests/test_google_auth_httplib2.py
+++ b/tests/test_google_auth_httplib2.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import httplib2
-import mock
 import six
 from six.moves import http_client
+import mock
 
 import google_auth_httplib2
 from tests import compliance

--- a/tests/test_google_auth_httplib2.py
+++ b/tests/test_google_auth_httplib2.py
@@ -99,7 +99,7 @@ class TestAuthorizedHttp(object):
     def test_follow_redirects(self):
         authed_http = google_auth_httplib2.AuthorizedHttp(mock.sentinel.credentials)
 
-        assert authed_http.connections == authed_http.http.connections
+        assert authed_http.follow_redirects == authed_http.http.follow_redirects
 
         authed_http.follow_redirects = mock.sentinel.follow_redirects
         assert authed_http.http.follow_redirects == mock.sentinel.follow_redirects
@@ -113,7 +113,10 @@ class TestAuthorizedHttp(object):
         assert authed_http.http.timeout == mock.sentinel.timeout
 
     def test_add_certificate(self):
-        authed_http = google_auth_httplib2.AuthorizedHttp(mock.sentinel.credentials)
+        authed_http = google_auth_httplib2.AuthorizedHttp(
+            mock.sentinel.credentials,
+            http=MockHttp(MockResponse())
+        )
 
         authed_http.add_certificate("key", "cert", "domain", password="password")
         authed_http.http.add_certificate.assert_called_once_with(

--- a/tests/test_google_auth_httplib2.py
+++ b/tests/test_google_auth_httplib2.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import httplib2
+import mock
 import six
 from six.moves import http_client
-import mock
 
 import google_auth_httplib2
 from tests import compliance


### PR DESCRIPTION
expose a few httplib2 properties and a method to help gcloud migration from httplib2 to google-auth-httplib2

Linter seems to have some problem, so I have to disable 2 rules:
(1) useless-object-inheritance: linter doesn't like class to inherits object in `class AuthorizedHttp(object)`
(2) wrong-import-order: linter complains wrong import order, but it contradicts itself, for instance, 
```
tests/test_google_auth_httplib2.py:18:0: C0411: third party import 
"from six.moves import http_client" should be placed before "import mock" (wrong-import-order)
```
and after changing it:
```
tests/test_google_auth_httplib2.py:18:1: I100 Import statements are in the wrong order.
 'import mock' should be before 'from six.moves import http_client'
```
 However, original order doesn't seem to be wrong.