### PR TITLE
Expose redirect_codes on AuthorizedHttp.

### DIFF
--- a/google_auth_httplib2.py
+++ b/google_auth_httplib2.py
@@ -260,3 +260,13 @@ class AuthorizedHttp(object):
     def timeout(self, value):
         """Proxy to httplib2.Http.timeout."""
         self.http.timeout = value
+
+    @property
+    def redirect_codes(self):
+        """Proxy to httplib2.Http.redirect_codes."""
+        return self.http.redirect_codes
+
+    @redirect_codes.setter
+    def redirect_codes(self, value):
+        """Proxy to httplib2.Http.redirect_codes."""
+        self.http.redirect_codes = value

--- a/tests/test_google_auth_httplib2.py
+++ b/tests/test_google_auth_httplib2.py
@@ -117,6 +117,16 @@ class TestAuthorizedHttp(object):
         authed_http.timeout = mock.sentinel.timeout
         assert authed_http.http.timeout == mock.sentinel.timeout
 
+    def test_redirect_codes(self):
+        authed_http = google_auth_httplib2.AuthorizedHttp(
+            mock.sentinel.credentials
+        )
+
+        assert authed_http.redirect_codes == authed_http.http.redirect_codes
+
+        authed_http.redirect_codes = mock.sentinel.redirect_codes
+        assert authed_http.http.redirect_codes == mock.sentinel.redirect_codes
+
     def test_add_certificate(self):
         authed_http = google_auth_httplib2.AuthorizedHttp(
             mock.sentinel.credentials,


### PR DESCRIPTION
Similar to #9, this exposes the `redirect_codes` attribute of the underlying
httplib2.Http instance on AuthorizedHttp, letting users modify the set of HTTP
status codes interpreted as redirects (as in
https://github.com/googleapis/google-api-python-client/issues/803).

PTAL @busunkim96 