### PR TITLE
Fix the signature of AuthorizedHttp.request to match the signature of the request in httplib2

### DIFF
--- a/google_auth_httplib2.py
+++ b/google_auth_httplib2.py
@@ -176,6 +176,8 @@ class AuthorizedHttp(object):
         self._request = Request(self.http)
 
     def request(self, uri, method='GET', body=None, headers=None,
+                redirections=httplib2.DEFAULT_MAX_REDIRECTS,
+                connection_type=None,
                 **kwargs):
         """Implementation of httplib2's Http.request."""
 
@@ -198,7 +200,8 @@ class AuthorizedHttp(object):
 
         # Make the request.
         response, content = self.http.request(
-            uri, method, body=body, headers=request_headers, **kwargs)
+            uri, method, body=body, headers=request_headers,
+            redirections=redirections, connection_type=connection_type)
 
         # If the response indicated that the credentials needed to be
         # refreshed, then refresh the credentials and re-attempt the
@@ -222,8 +225,8 @@ class AuthorizedHttp(object):
             # Recurse. Pass in the original headers, not our modified set.
             return self.request(
                 uri, method, body=body, headers=headers,
-                _credential_refresh_attempt=_credential_refresh_attempt + 1,
-                **kwargs)
+                redirections=redirections, connection_type=connection_type,
+                _credential_refresh_attempt=_credential_refresh_attempt + 1)
 
         return response, content
 

--- a/google_auth_httplib2.py
+++ b/google_auth_httplib2.py
@@ -201,7 +201,8 @@ class AuthorizedHttp(object):
         # Make the request.
         response, content = self.http.request(
             uri, method, body=body, headers=request_headers,
-            redirections=redirections, connection_type=connection_type)
+            redirections=redirections, connection_type=connection_type,
+            **kwargs)
 
         # If the response indicated that the credentials needed to be
         # refreshed, then refresh the credentials and re-attempt the
@@ -226,7 +227,8 @@ class AuthorizedHttp(object):
             return self.request(
                 uri, method, body=body, headers=headers,
                 redirections=redirections, connection_type=connection_type,
-                _credential_refresh_attempt=_credential_refresh_attempt + 1)
+                _credential_refresh_attempt=_credential_refresh_attempt + 1,
+                **kwargs)
 
         return response, content
 

--- a/tests/test_google_auth_httplib2.py
+++ b/tests/test_google_auth_httplib2.py
@@ -28,8 +28,11 @@ class MockHttp(object):
         self.headers = headers or {}
         self.add_certificate = mock.Mock(return_value=None)
 
-    def request(self, url, method='GET', body=None, headers=None, **kwargs):
-        self.requests.append((method, url, body, headers, kwargs))
+    def request(self, url, method='GET', body=None, headers=None,
+                redirections=httplib2.DEFAULT_MAX_REDIRECTS,
+                connection_type=None):
+        self.requests.append(
+            (method, url, body, headers, redirections, connection_type))
         return self.responses.pop(0)
 
 
@@ -55,7 +58,7 @@ class TestRequestResponse(compliance.RequestResponseTests):
         request(url=url, method='GET', timeout=5)
 
         assert http.requests[0] == (
-            'GET', url, None, None, {})
+            'GET', url, None, None, httplib2.DEFAULT_MAX_REDIRECTS, None)
 
 
 def test__make_default_http():
@@ -155,7 +158,8 @@ class TestAuthorizedHttp(object):
         assert mock_credentials.before_request.called
         assert not mock_credentials.refresh.called
         assert mock_http.requests == [
-            ('GET', self.TEST_URL, None, {'authorization': 'token'}, {})]
+            ('GET', self.TEST_URL, None, {'authorization': 'token'},
+            httplib2.DEFAULT_MAX_REDIRECTS, None)]
 
     def test_request_refresh(self):
         mock_credentials = mock.Mock(wraps=MockCredentials())
@@ -175,8 +179,10 @@ class TestAuthorizedHttp(object):
         assert mock_credentials.before_request.call_count == 2
         assert mock_credentials.refresh.called
         assert mock_http.requests == [
-            ('GET', self.TEST_URL, None, {'authorization': 'token'}, {}),
-            ('GET', self.TEST_URL, None, {'authorization': 'token1'}, {})]
+            ('GET', self.TEST_URL, None, {'authorization': 'token'},
+                httplib2.DEFAULT_MAX_REDIRECTS, None),
+            ('GET', self.TEST_URL, None, {'authorization': 'token1'},
+                httplib2.DEFAULT_MAX_REDIRECTS, None)]
 
     def test_request_stream_body(self):
         mock_credentials = mock.Mock(wraps=MockCredentials())
@@ -198,5 +204,28 @@ class TestAuthorizedHttp(object):
         assert response == mock_response
         assert data == mock_response.data
         assert mock_http.requests == [
-            ('POST', self.TEST_URL, body, {'authorization': 'token'}, {}),
-            ('POST', self.TEST_URL, body, {'authorization': 'token1'}, {})]
+            ('POST', self.TEST_URL, body, {'authorization': 'token'},
+                httplib2.DEFAULT_MAX_REDIRECTS, None),
+            ('POST', self.TEST_URL, body, {'authorization': 'token1'},
+                httplib2.DEFAULT_MAX_REDIRECTS, None)]
+
+    def test_request_positional_args(self):
+        """Verifies that clients can pass args to request as positioanls."""
+        mock_credentials = mock.Mock(wraps=MockCredentials())
+        mock_response = MockResponse()
+        mock_http = MockHttp([mock_response])
+
+        authed_http = google_auth_httplib2.AuthorizedHttp(
+            mock_credentials, http=mock_http)
+
+        response, data = authed_http.request(
+            self.TEST_URL, 'GET', None, None,
+            httplib2.DEFAULT_MAX_REDIRECTS, None)
+
+        assert response == mock_response
+        assert data == mock_response.data
+        assert mock_credentials.before_request.called
+        assert not mock_credentials.refresh.called
+        assert mock_http.requests == [
+            ('GET', self.TEST_URL, None, {'authorization': 'token'},
+                httplib2.DEFAULT_MAX_REDIRECTS, None)]

--- a/tests/test_google_auth_httplib2.py
+++ b/tests/test_google_auth_httplib2.py
@@ -159,7 +159,7 @@ class TestAuthorizedHttp(object):
         assert not mock_credentials.refresh.called
         assert mock_http.requests == [
             ('GET', self.TEST_URL, None, {'authorization': 'token'},
-            httplib2.DEFAULT_MAX_REDIRECTS, None)]
+                httplib2.DEFAULT_MAX_REDIRECTS, None)]
 
     def test_request_refresh(self):
         mock_credentials = mock.Mock(wraps=MockCredentials())


### PR DESCRIPTION
The current signature of AuthorizedHttp.request is request(self, uri, method='GET', body=None, headers=None, **kwargs). If client calls request(self.TEST_URL, 'GET', None, None, httplib2.DEFAULT_MAX_REDIRECTS, None), it crashes. However this way is accepted by the httplib2.Http.request. 